### PR TITLE
docs: fix simple typo, instace -> instance

### DIFF
--- a/examples/profile/dv.profile.js
+++ b/examples/profile/dv.profile.js
@@ -57,7 +57,7 @@ function dv_profile_cache(evt, query) {
     return idx.map(function(j) { return dat[j]; });
 }
 
-// Profiler instace to manage plots and coordinate linked selections
+// Profiler instance to manage plots and coordinate linked selections
 dv.profile = function(data) {
     var g = [],
         add = function(vis) { qdata = null; g.push(vis); return vis; },


### PR DESCRIPTION
There is a small typo in examples/profile/dv.profile.js.

Should read `instance` rather than `instace`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md